### PR TITLE
Add rustc_cargo_manifest_dir_requires_bin_dir attr to rust_library

### DIFF
--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -1160,6 +1160,9 @@ _annotation = tag_class(
         "rustc_env_files": _relative_label_list(
             doc = "A list of labels to set on a crate's `rust_library::rustc_env_files` attribute.",
         ),
+        "rustc_cargo_manifest_dir_requires_bin_dir": attr.bool(
+            doc = "If the library CARGO_MANIFEST_DIR needs the ctx.bin_dir included.",
+        ),
         "rustc_flags": attr.string_list(
             doc = "A list of strings to set on a crate's `rust_library::rustc_flags` attribute.",
         ),

--- a/crate_universe/private/crate.bzl
+++ b/crate_universe/private/crate.bzl
@@ -114,6 +114,7 @@ def _annotation(
         proc_macro_deps = None,
         rustc_env = None,
         rustc_env_files = None,
+        rustc_cargo_manifest_dir_requires_bin_dir = None,
         rustc_flags = None,
         shallow_since = None,
         override_targets = None):
@@ -169,6 +170,7 @@ def _annotation(
         rustc_env (dict, optional): Additional variables to set on a crate's `rust_library::rustc_env` attribute.
         rustc_env_files (list, optional): A list of labels to set on a crate's `rust_library::rustc_env_files`
             attribute.
+        rustc_cargo_manifest_dir_requires_bin_dir (bool, optional): See doc elsewhere.
         rustc_flags (list, optional): A list of strings to set on a crate's `rust_library::rustc_flags` attribute.
         shallow_since (str, optional): An optional timestamp used for crates originating from a git repository
             instead of a crate registry. This flag optimizes fetching the source code.
@@ -217,6 +219,7 @@ def _annotation(
             proc_macro_deps = _stringify_list(proc_macro_deps),
             rustc_env = rustc_env,
             rustc_env_files = _stringify_list(rustc_env_files),
+            rustc_cargo_manifest_dir_requires_bin_dir = rustc_cargo_manifest_dir_requires_bin_dir,
             rustc_flags = rustc_flags,
             shallow_since = shallow_since,
             override_targets = override_targets,

--- a/rust/private/providers.bzl
+++ b/rust/private/providers.bzl
@@ -34,6 +34,7 @@ CrateInfo = provider(
         "rustc_env_files": "[File]: Files containing additional environment variables to set for rustc.",
         "rustc_output": "File: The output from rustc from producing the output file. It is optional.",
         "rustc_rmeta_output": "File: The rmeta file produced for this crate. It is optional.",
+        "rustc_cargo_manifest_dir_requires_bin_dir": "bool: If the crate requires a bin dir in the CARGO_MANIFEST_DIR. It is optional.",
         "srcs": "depset[File]: All source Files that are part of the crate.",
         "std_dylib": "File: libstd.so file",
         "type": (

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -200,6 +200,7 @@ def _rust_library_common(ctx, crate_type):
             edition = get_edition(ctx.attr, toolchain, ctx.label),
             rustc_env = ctx.attr.rustc_env,
             rustc_env_files = ctx.files.rustc_env_files,
+            rustc_cargo_manifest_dir_requires_bin_dir = ctx.attr.rustc_cargo_manifest_dir_requires_bin_dir,
             is_test = False,
             data = depset(ctx.files.data),
             compile_data = depset(compile_data),
@@ -252,6 +253,7 @@ def _rust_binary_impl(ctx):
             edition = get_edition(ctx.attr, toolchain, ctx.label),
             rustc_env = ctx.attr.rustc_env,
             rustc_env_files = ctx.files.rustc_env_files,
+            rustc_cargo_manifest_dir_requires_bin_dir = ctx.attr.rustc_cargo_manifest_dir_requires_bin_dir,
             is_test = False,
             data = depset(ctx.files.data),
             compile_data = depset(compile_data),
@@ -717,6 +719,10 @@ _common_attrs = {
     "version": attr.string(
         doc = "A version to inject in the cargo environment variable.",
         default = "0.0.0",
+    ),
+    "rustc_cargo_manifest_dir_requires_bin_dir": attr.bool(
+        doc = "If the crate requires a bin dir in the CARGO_MANIFEST_DIR.",
+        default = False,
     ),
     "_stamp_flag": attr.label(
         doc = "A setting used to determine whether or not the `--stamp` flag is enabled",

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -905,7 +905,11 @@ def construct_arguments(
 
     # Both ctx.label.workspace_root and ctx.label.package are relative paths
     # and either can be empty strings. Avoid trailing/double slashes in the path.
+
     components = "${{pwd}}/{}/{}".format(ctx.label.workspace_root, ctx.label.package).split("/")
+    if crate_info.rustc_cargo_manifest_dir_requires_bin_dir:
+        components = "${{pwd}}/{}/{}/{}".format(ctx.label.workspace_root, ctx.bin_dir.path, ctx.label.package).split("/")
+
     env["CARGO_MANIFEST_DIR"] = "/".join([c for c in components if c])
 
     if out_dir != None:


### PR DESCRIPTION
This is a temporarry workaround for the issue whereing the directory for CARGO_MANIFEST_DIR is off by ctx.bin_dir.path.

See https://bazelbuild.slack.com/archives/CSV56UT0F/p1737790747209019