### PR TITLE
Add CARGO_MANIFEST_DIR_NEEDS_BIN_DIR

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -906,6 +906,8 @@ def construct_arguments(
     # Both ctx.label.workspace_root and ctx.label.package are relative paths
     # and either can be empty strings. Avoid trailing/double slashes in the path.
     components = "${{pwd}}/{}/{}".format(ctx.label.workspace_root, ctx.label.package).split("/")
+    if "true" == crate_info.rustc_env.get("CARGO_MANIFEST_DIR_NEEDS_BIN_DIR"):
+        components = "${{pwd}}/{}/{}/{}".format(ctx.bin_dir.path, ctx.label.workspace_root, ctx.label.package).split("/")
     env["CARGO_MANIFEST_DIR"] = "/".join([c for c in components if c])
 
     if out_dir != None:


### PR DESCRIPTION
If CARGO_MANIFEST_DIR_NEEDS_BIN_DIR=true is added to the rustc_env dict, the generated CARGO_MANIFEST_DIR will include the ctx.bin_dir.path as as prefix.